### PR TITLE
Add ARMv8 support

### DIFF
--- a/include/tbb/tbb_machine.h
+++ b/include/tbb/tbb_machine.h
@@ -241,8 +241,8 @@ template<> struct atomic_selector<8> {
         #include "machine/linux_ia64.h"
     #elif __powerpc__
         #include "machine/mac_ppc.h"
-    #elif __ARM_ARCH_7A__
-        #include "machine/gcc_armv7.h"
+    #elif __ARM_ARCH_7A__ || __aarch64__
+        #include "machine/gcc_arm.h"
     #elif __TBB_GCC_BUILTIN_ATOMICS_PRESENT
         #include "machine/gcc_generic.h"
     #endif


### PR DESCRIPTION
This patch adds ARMv8 support for libtbb and provides an optimized
__TBB_Pause implementation that avoids sched_yield.

I've taken the minimal approach to leave the current armv7 support mostly untouched, with the exception of __TBB_machine pause.  The aarch64 support mostly draws from gcc_generic.h since it provides a reasonable starting point for the implementation.  I've build-tested the -march=armv7-a on a raspberry pi and a full test on aarch64.