### PR TITLE
fixed HashCompare constructor in concurrent_hash_map

### DIFF
--- a/include/tbb/concurrent_hash_map.h
+++ b/include/tbb/concurrent_hash_map.h
@@ -755,13 +755,13 @@ public:
     };
 
     //! Construct empty table.
-    explicit concurrent_hash_map( const allocator_type &a = allocator_type() )
-        : internal::hash_map_base(), my_allocator(a)
+    explicit concurrent_hash_map( const HashCompare &c = HashCompare(), const allocator_type &a = allocator_type() )
+        : internal::hash_map_base(), my_hash_compare(c), my_allocator(a)
     {}
 
     //! Construct empty table with n preallocated buckets. This number serves also as initial concurrency level.
-    concurrent_hash_map( size_type n, const allocator_type &a = allocator_type() )
-        : my_allocator(a)
+    concurrent_hash_map( size_type n, const HashCompare &c = HashCompare(), const allocator_type &a = allocator_type() )
+        : my_hash_compare(c), my_allocator(a)
     {
         reserve( n );
     }
@@ -799,8 +799,8 @@ public:
 
     //! Construction with copying iteration range and given allocator instance
     template<typename I>
-    concurrent_hash_map( I first, I last, const allocator_type &a = allocator_type() )
-        : my_allocator(a)
+    concurrent_hash_map( I first, I last, const HashCompare &c = HashCompare(), const allocator_type &a = allocator_type() )
+        : my_hash_compare(c), my_allocator(a)
     {
         call_clear_on_leave scope_guard(this);
         internal_copy(first, last, std::distance(first, last));
@@ -809,8 +809,8 @@ public:
 
 #if __TBB_INITIALIZER_LISTS_PRESENT
     //! Construct empty table with n preallocated buckets. This number serves also as initial concurrency level.
-    concurrent_hash_map( std::initializer_list<value_type> il, const allocator_type &a = allocator_type() )
-        : my_allocator(a)
+    concurrent_hash_map( std::initializer_list<value_type> il, const HashCompare &c = HashCompare(),  const allocator_type &a = allocator_type() )
+        : my_hash_compare(c), my_allocator(a)
     {
         call_clear_on_leave scope_guard(this);
         internal_copy(il.begin(), il.end(), il.size());


### PR DESCRIPTION
Hi,
  This is a followup fix on the issue reported on the TBB forum. https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/780000.

Now the example in the gist can build and work. 
https://gist.github.com/arewedancer/a6ac95ddd800b4da27a943a406bf8226

Thanks!