### PR TITLE
Fix detection of clang version when CUDA toolkit is installed

### DIFF
--- a/build/BSD.inc
+++ b/build/BSD.inc
@@ -25,7 +25,7 @@ ifndef arch
 endif
 
 ifndef runtime
-        clang_version:=$(shell clang -v 2>&1 | grep version | sed "s/.*version \([0-9]*\.[0-9]*\).*/\1/")
+        clang_version:=$(shell clang --version | sed -n "1s/.*version \(.*[0-9]\) .*/\1/p")
         os_version:=$(shell uname -r)
         os_kernel_version:=$(shell uname -r | sed -e 's/-.*$$//')
         export runtime:=cc$(clang_version)_kernel$(os_kernel_version)

--- a/build/macos.inc
+++ b/build/macos.inc
@@ -45,7 +45,7 @@ ifndef arch
 endif
 
 ifndef runtime
-  clang_version:=$(shell clang -v 2>&1 >/dev/null | grep version | sed -e "s/.*version \(.*[0-9]\) .*/\1/")
+  clang_version:=$(shell clang --version | sed -n "1s/.*version \(.*[0-9]\) .*/\1/p")
   ifndef os_version
     os_version:=$(shell /usr/bin/sw_vers -productVersion)
   endif


### PR DESCRIPTION
When CUDA toolkit is installed, the version of `clang` is not detected properly.
See https://sft.its.cern.ch/jira/browse/ROOT-9678 for the original report.

Before this change:
```sh
$ clang -v 2>&1 >/dev/null | grep version | sed -e "s/.*version \(.*[0-9]\) .*/\1/"
10.0.0
Found CUDA installation: /usr/local/cuda, version unknown
```
After this change:
```sh
clang --version | sed -n "1s/.*version \(.*[0-9]\) .*/\1/p"
10.0.0
```