### PR TITLE
Fix gcc warning -Wclass-memaccess

### DIFF
--- a/include/tbb/concurrent_hash_map.h
+++ b/include/tbb/concurrent_hash_map.h
@@ -122,7 +122,7 @@ namespace interface5 {
 #endif
         //! Constructor
         hash_map_base() {
-            std::memset( this, 0, pointers_per_table*sizeof(segment_ptr_t) // 32*4=128   or 64*8=512
+            std::memset( static_cast<void*>(this), 0, pointers_per_table*sizeof(segment_ptr_t) // 32*4=128   or 64*8=512
                 + sizeof(my_size) + sizeof(my_mask)  // 4+4 or 8+8
                 + embedded_buckets*sizeof(bucket) ); // n*8 or n*16
             for( size_type i = 0; i < embedded_block; i++ ) // fill the table


### PR DESCRIPTION
 Fixes https://github.com/intel/tbb/issues/134

The warning was introduced in gcc 8.0: https://gcc.gnu.org/gcc-8/changes.html

Warning is documented at https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wclass-memaccess

Relevant gcc bug reports:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81327

Original patch discussion:

https://gcc.gnu.org/ml/gcc-patches/2017-04/msg01571.html