### PR TITLE
Added support for move-only types to tbb::parallel_pipeline

### DIFF
--- a/include/tbb/pipeline.h
+++ b/include/tbb/pipeline.h
@@ -26,6 +26,10 @@
 #include <type_traits>
 #endif
 
+#if __TBB_CPP11_RVALUE_REF_PRESENT
+#include <utility> // for std::move
+#endif
+
 namespace tbb {
 
 class pipeline;
@@ -61,7 +65,7 @@ namespace interface6 {
 class filter: internal::no_copy {
 private:
     //! Value used to mark "not in pipeline"
-    static filter* not_in_pipeline() {return reinterpret_cast<filter*>(intptr_t(-1));}
+    static filter* not_in_pipeline() { return reinterpret_cast<filter*>(intptr_t(-1)); }
 protected:
     //! The lowest bit 0 is for parallel vs. serial
     static const unsigned char filter_is_serial = 0x1;
@@ -153,7 +157,7 @@ public:
     //! Destroys item if pipeline was cancelled.
     /** Required to prevent memory leaks.
         Note it can be called concurrently even for serial filters.*/
-    virtual void finalize( void* /*item*/ ) {};
+    virtual void finalize( void* /*item*/ ) {}
 #endif
 
 private:
@@ -315,43 +319,60 @@ public:
 //! @cond INTERNAL
 namespace internal {
 
-template<typename T> struct tbb_large_object {enum { value = sizeof(T) > sizeof(void *) }; };
-
-// Obtain type properties in one or another way
+// Emulate std::is_trivially_copyable (false positives not allowed, false negatives suboptimal but safe).
 #if   __TBB_CPP11_TYPE_PROPERTIES_PRESENT
 template<typename T> struct tbb_trivially_copyable { enum { value = std::is_trivially_copyable<T>::value }; };
 #elif __TBB_TR1_TYPE_PROPERTIES_IN_STD_PRESENT
 template<typename T> struct tbb_trivially_copyable { enum { value = std::has_trivial_copy_constructor<T>::value }; };
 #else
-// Explicitly list the types we wish to be placed as-is in the pipeline input_buffers.
-template<typename T> struct tbb_trivially_copyable { enum { value = false }; };
-template<typename T> struct tbb_trivially_copyable <T*> { enum { value = true }; };
-template<> struct tbb_trivially_copyable <short> { enum { value = true }; };
-template<> struct tbb_trivially_copyable <unsigned short> { enum { value = true }; };
-template<> struct tbb_trivially_copyable <int> { enum { value = !tbb_large_object<int>::value }; };
-template<> struct tbb_trivially_copyable <unsigned int> { enum { value = !tbb_large_object<int>::value }; };
-template<> struct tbb_trivially_copyable <long> { enum { value = !tbb_large_object<long>::value }; };
-template<> struct tbb_trivially_copyable <unsigned long> { enum { value = !tbb_large_object<long>::value }; };
-template<> struct tbb_trivially_copyable <float> { enum { value = !tbb_large_object<float>::value }; };
-template<> struct tbb_trivially_copyable <double> { enum { value = !tbb_large_object<double>::value }; };
-#endif // Obtaining type properties
+template<typename T> struct tbb_trivially_copyable                      { enum { value = false }; };
+template<typename T> struct tbb_trivially_copyable <         T*       > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         bool     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         char     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <  signed char     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <unsigned char     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         short    > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <unsigned short    > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         int      > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <unsigned int      > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         long     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <unsigned long     > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         long long> { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <unsigned long long> { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         float    > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <         double   > { enum { value = true  }; };
+template<>           struct tbb_trivially_copyable <    long double   > { enum { value = true  }; };
+#if !_MSC_VER || defined(_NATIVE_WCHAR_T_DEFINED)
+template<>           struct tbb_trivially_copyable <         wchar_t  > { enum { value = true  }; };
+#endif /* _MSC_VER||!defined(_NATIVE_WCHAR_T_DEFINED) */
+#endif // tbb_trivially_copyable
 
-template<typename T> struct is_large_object {enum { value = tbb_large_object<T>::value || !tbb_trivially_copyable<T>::value }; };
+template<typename T>
+struct use_allocator {
+    enum { value = sizeof(T) > sizeof(void *) || !tbb_trivially_copyable<T>::value };
+};
 
 template<typename T, bool> class token_helper;
 
-// large object helper (uses tbb_allocator)
+// using tbb_allocator
 template<typename T>
 class token_helper<T, true> {
     public:
     typedef typename tbb::tbb_allocator<T> allocator;
     typedef T* pointer;
     typedef T value_type;
+#if __TBB_CPP11_RVALUE_REF_PRESENT
+    static pointer create_token(value_type && source) {
+        pointer output_t = allocator().allocate(1);
+        return new (output_t) T(std::move(source));
+    }
+#else
     static pointer create_token(const value_type & source) {
         pointer output_t = allocator().allocate(1);
         return new (output_t) T(source);
     }
-    static value_type & token(pointer & t) { return *t;}
+#endif
+    static value_type & token(pointer & t) { return *t; }
     static void * cast_to_void_ptr(pointer ref) { return (void *) ref; }
     static pointer cast_from_void_ptr(void * ref) { return (pointer)ref; }
     static void destroy_token(pointer token) {
@@ -367,13 +388,13 @@ class token_helper<T*, false > {
     typedef T* pointer;
     typedef T* value_type;
     static pointer create_token(const value_type & source) { return source; }
-    static value_type & token(pointer & t) { return t;}
+    static value_type & token(pointer & t) { return t; }
     static void * cast_to_void_ptr(pointer ref) { return (void *)ref; }
     static pointer cast_from_void_ptr(void * ref) { return (pointer)ref; }
     static void destroy_token( pointer /*token*/) {}
 };
 
-// small object specialization (converts void* to the correct type, passes objects directly.)
+// converting type to and from void*, passing objects directly
 template<typename T>
 class token_helper<T, false> {
     typedef union {
@@ -383,9 +404,8 @@ class token_helper<T, false> {
     public:
     typedef T pointer;  // not really a pointer in this case.
     typedef T value_type;
-    static pointer create_token(const value_type & source) {
-        return source; }
-    static value_type & token(pointer & t) { return t;}
+    static pointer create_token(const value_type & source) { return source; }
+    static value_type & token(pointer & t) { return t; }
     static void * cast_to_void_ptr(pointer ref) {
         type_to_void_ptr_map mymap;
         mymap.void_overlay = NULL;
@@ -400,17 +420,22 @@ class token_helper<T, false> {
     static void destroy_token( pointer /*token*/) {}
 };
 
+// intermediate
 template<typename T, typename U, typename Body>
 class concrete_filter: public tbb::filter {
     const Body& my_body;
-    typedef token_helper<T,is_large_object<T>::value > t_helper;
+    typedef token_helper<T,use_allocator<T>::value > t_helper;
     typedef typename t_helper::pointer t_pointer;
-    typedef token_helper<U,is_large_object<U>::value > u_helper;
+    typedef token_helper<U,use_allocator<U>::value > u_helper;
     typedef typename u_helper::pointer u_pointer;
 
     void* operator()(void* input) __TBB_override {
         t_pointer temp_input = t_helper::cast_from_void_ptr(input);
-        u_pointer output_u = u_helper::create_token(my_body(t_helper::token(temp_input)));
+#if __TBB_CPP11_RVALUE_REF_PRESENT
+        u_pointer output_u = u_helper::create_token(my_body(std::move(t_helper::token(temp_input))));
+#else
+        u_pointer output_u = u_helper::create_token(my_body(          t_helper::token(temp_input) ));
+#endif
         t_helper::destroy_token(temp_input);
         return u_helper::cast_to_void_ptr(output_u);
     }
@@ -428,7 +453,7 @@ public:
 template<typename U, typename Body>
 class concrete_filter<void,U,Body>: public filter {
     const Body& my_body;
-    typedef token_helper<U, is_large_object<U>::value > u_helper;
+    typedef token_helper<U, use_allocator<U>::value > u_helper;
     typedef typename u_helper::pointer u_pointer;
 
     void* operator()(void*) __TBB_override {
@@ -449,15 +474,20 @@ public:
     {}
 };
 
+// output
 template<typename T, typename Body>
 class concrete_filter<T,void,Body>: public filter {
     const Body& my_body;
-    typedef token_helper<T, is_large_object<T>::value > t_helper;
+    typedef token_helper<T, use_allocator<T>::value > t_helper;
     typedef typename t_helper::pointer t_pointer;
 
     void* operator()(void* input) __TBB_override {
         t_pointer temp_input = t_helper::cast_from_void_ptr(input);
-        my_body(t_helper::token(temp_input));
+#if __TBB_CPP11_RVALUE_REF_PRESENT
+        my_body(std::move(t_helper::token(temp_input)));
+#else
+        my_body(          t_helper::token(temp_input) );
+#endif
         t_helper::destroy_token(temp_input);
         return NULL;
     }
@@ -514,7 +544,7 @@ public:
     //! Add concrete_filter to pipeline
     virtual void add_to( pipeline& ) = 0;
     //! Increment reference count
-    void add_ref() {++ref_count;}
+    void add_ref() { ++ref_count; }
     //! Decrement reference count and delete if it becomes zero.
     void remove_ref() {
         __TBB_ASSERT(ref_count>0,"ref_count underflow");
@@ -530,7 +560,7 @@ public:
 
 //! Node in parse tree representing result of make_filter.
 template<typename T, typename U, typename Body>
-class filter_node_leaf: public filter_node  {
+class filter_node_leaf: public filter_node {
     const tbb::filter::mode mode;
     const Body body;
     void add_to( pipeline& p ) __TBB_override {

--- a/src/test/test_parallel_pipeline.cpp
+++ b/src/test/test_parallel_pipeline.cpp
@@ -651,22 +651,22 @@ int TestMain() {
 
         // Run test several times with different types
         run_function_spec();
-        #define M(type1, type2) run_function<type1, type2>(#type1, #type2);
-        M(size_t, int)
-        M(int, double)
-        M(size_t, double)
-        M(size_t, bool)
-        M(int, int)
-        M(check_type<unsigned int>, size_t)
-        M(check_type<unsigned short>, size_t)
-        M(check_type<unsigned int>, check_type<unsigned int>)
-        M(check_type<unsigned int>, check_type<unsigned short>)
-        M(check_type<unsigned short>, check_type<unsigned short>)
-        M(double, check_type<unsigned short>)
+        #define RUN_FUNCTION(type1, type2) run_function<type1, type2>(#type1, #type2);
+        RUN_FUNCTION(size_t, int)
+        RUN_FUNCTION(int, double)
+        RUN_FUNCTION(size_t, double)
+        RUN_FUNCTION(size_t, bool)
+        RUN_FUNCTION(int, int)
+        RUN_FUNCTION(check_type<unsigned int>, size_t)
+        RUN_FUNCTION(check_type<unsigned short>, size_t)
+        RUN_FUNCTION(check_type<unsigned int>, check_type<unsigned int>)
+        RUN_FUNCTION(check_type<unsigned int>, check_type<unsigned short>)
+        RUN_FUNCTION(check_type<unsigned short>, check_type<unsigned short>)
+        RUN_FUNCTION(double, check_type<unsigned short>)
 #if __TBB_CPP11_RVALUE_REF_PRESENT
-        M(std::unique_ptr<int>, std::unique_ptr<int>) // move-only type
+        RUN_FUNCTION(std::unique_ptr<int>, std::unique_ptr<int>) // move-only type
 #endif
-        #undef M
+        #undef RUN_FUNCTION
     }
     return Harness::Done;
 }

--- a/src/test/test_parallel_pipeline.cpp
+++ b/src/test/test_parallel_pipeline.cpp
@@ -636,12 +636,12 @@ void run_function(const char *l1, const char *l2) {
 int TestMain() {
 #if TBB_USE_DEBUG
     // size and copyability.
-    REMARK("is_large_object<int>::value=%d\n", tbb::interface6::internal::is_large_object<int>::value);
-    REMARK("is_large_object<double>::value=%d\n", tbb::interface6::internal::is_large_object<double>::value);
-    REMARK("is_large_object<int *>::value=%d\n", tbb::interface6::internal::is_large_object<int *>::value);
-    REMARK("is_large_object<check_type<int> >::value=%d\n", tbb::interface6::internal::is_large_object<check_type<int> >::value);
-    REMARK("is_large_object<check_type<int>* >::value=%d\n", tbb::interface6::internal::is_large_object<check_type<int>* >::value);
-    REMARK("is_large_object<check_type<short> >::value=%d\n\n", tbb::interface6::internal::is_large_object<check_type<short> >::value);
+    REMARK("use_allocator<int>::value=%d\n", tbb::interface6::internal::use_allocator<int>::value);
+    REMARK("use_allocator<double>::value=%d\n", tbb::interface6::internal::use_allocator<double>::value);
+    REMARK("use_allocator<int *>::value=%d\n", tbb::interface6::internal::use_allocator<int *>::value);
+    REMARK("use_allocator<check_type<int> >::value=%d\n", tbb::interface6::internal::use_allocator<check_type<int> >::value);
+    REMARK("use_allocator<check_type<int>* >::value=%d\n", tbb::interface6::internal::use_allocator<check_type<int>* >::value);
+    REMARK("use_allocator<check_type<short> >::value=%d\n\n", tbb::interface6::internal::use_allocator<check_type<short> >::value);
 #endif
     // Test with varying number of threads.
     for( int nthread=MinThread; nthread<=MaxThread; ++nthread ) {


### PR DESCRIPTION
I had a need to pass something like `std::vector<std::unique_ptr<something>>`, which was not supported. These are the necessary changes (or at least I assume it now supports the above type as well as simply `std::unique_ptr<int>`), plus some pedantic editing, including frivolous reformatting as well as a proposal to be more precise, e.g., about what really is meant by `tbb_trivially_copyable` and large objects, for the latter substituting `use_allocator` instead.