### PR TITLE
fix gcc 9.1 -Wdeprecated-copy warnings by declaring default copy constructor and assignment operators

### DIFF
--- a/include/tbb/atomic.h
+++ b/include/tbb/atomic.h
@@ -416,6 +416,7 @@ struct atomic: internal::atomic_impl<T> {
     #define __TBB_DECL_ATOMIC(T)                                                                    \
         template<> struct atomic<T>: internal::atomic_impl_with_arithmetic<T,T,char> {              \
             atomic() = default;                                                                     \
+            constexpr atomic( const atomic<T>& rhs ) = default;                                     \
             constexpr atomic(T arg): internal::atomic_impl_with_arithmetic<T,T,char>(arg) {}        \
                                                                                                     \
             T operator=( T rhs ) {return store_with_release(rhs);}                                  \

--- a/include/tbb/concurrent_hash_map.h
+++ b/include/tbb/concurrent_hash_map.h
@@ -407,6 +407,9 @@ namespace interface5 {
             my_bucket(other.my_bucket),
             my_node(other.my_node)
         {}
+
+        hash_map_iterator& operator=( const hash_map_iterator<Container, Value> &other ) = default;
+
         Value& operator*() const {
             __TBB_ASSERT( hash_map_base::is_valid(my_node), "iterator uninitialized or at end of container?" );
             return my_node->value();

--- a/include/tbb/internal/_concurrent_unordered_impl.h
+++ b/include/tbb/internal/_concurrent_unordered_impl.h
@@ -84,6 +84,8 @@ public:
     flist_iterator( const flist_iterator<Solist, typename Solist::value_type> &other )
         : my_node_ptr(other.my_node_ptr) {}
 
+    flist_iterator& operator=( const flist_iterator<Solist, Value> &other ) = default;
+
     reference operator*() const { return my_node_ptr->my_element; }
     pointer operator->() const { return &**this; }
 

--- a/src/test/harness_iterator.h
+++ b/src/test/harness_iterator.h
@@ -125,6 +125,7 @@ public:
 
     explicit RandomIterator ( T * ptr ) : my_ptr(ptr){}
     RandomIterator ( const RandomIterator& r ) : my_ptr(r.my_ptr){}
+    RandomIterator& operator= ( const RandomIterator& r ) = default;
     T& operator* () const { return *my_ptr; }
     RandomIterator& operator++ () { ++my_ptr; return *this; }
     bool operator== ( const RandomIterator& r ) const { return my_ptr == r.my_ptr; }

--- a/src/test/harness_m128.h
+++ b/src/test/harness_m128.h
@@ -44,6 +44,7 @@ class ClassWithVectorType {
 public:
     ClassWithVectorType() {init(-n);}
     ClassWithVectorType( int i ) {init(i);}
+    constexpr ClassWithVectorType( const ClassWithVectorType& src ) = default;
     void operator=( const ClassWithVectorType& src ) {
         __Mvec stack[n];
         for( int i=0; i<n; ++i )

--- a/src/test/test_allocator.h
+++ b/src/test/test_allocator.h
@@ -46,6 +46,9 @@ struct Foo {
         *this = x;
         ++NumberOfFoo;
     }
+
+    Foo& operator=( const Foo& x ) = default;
+
     ~Foo() {
         --NumberOfFoo;
     }

--- a/src/test/test_concurrent_queue.cpp
+++ b/src/test/test_concurrent_queue.cpp
@@ -485,6 +485,7 @@ class BarIterator
     BarIterator(Bar* bp_) : bar_ptr(bp_) {}
 public:
     ~BarIterator() {}
+    constexpr BarIterator( const BarIterator& other ) = default;
     BarIterator& operator=( const BarIterator& other ) {
         bar_ptr = other.bar_ptr;
         return *this;


### PR DESCRIPTION
Part 1 fixes for https://github.com/intel/tbb/issues/161

