### PR TITLE
fix gcc 9.1 -Wdeprecated-copy warnings by replacing private assignment operators with deleted declarations

### DIFF
--- a/include/tbb/tbb_stddef.h
+++ b/include/tbb/tbb_stddef.h
@@ -318,9 +318,9 @@ inline T punned_cast( U* ptr ) {
 
 //! Base class for types that should not be assigned.
 class no_assign {
-    // Deny assignment
-    void operator=( const no_assign& );
 public:
+    // Deny assignment
+    void operator=( const no_assign& ) = delete;
 #if __GNUC__
     //! Explicitly define default construction, because otherwise gcc issues gratuitous warning.
     no_assign() {}

--- a/src/test/harness.h
+++ b/src/test/harness.h
@@ -445,9 +445,9 @@ int main(int argc, char* argv[]) {
 
 //! Base class for prohibiting compiler-generated operator=
 class NoAssign {
-    //! Assignment not allowed
-    void operator=( const NoAssign& );
 public:
+    //! Assignment not allowed
+    void operator=( const NoAssign& ) = delete;
     NoAssign() {} // explicitly defined to prevent gratuitous warnings
 };
 

--- a/src/test/test_concurrent_hash_map.cpp
+++ b/src/test/test_concurrent_hash_map.cpp
@@ -90,11 +90,11 @@ public:
     that concurrent_hash_map uses only the required interface. */
 class MyKey {
 private:
-    void operator=( const MyKey&  );    // Deny access
     int key;
     friend class MyHashCompare;
     friend class YourHashCompare;
 public:
+    void operator=( const MyKey&  ) = delete;    // Deny access
     static MyKey make( int i ) {
         MyKey result;
         result.key = i;


### PR DESCRIPTION
Part 2 fixes for https://github.com/intel/tbb/issues/161