### PR TITLE
Build warnings

### DIFF
--- a/include/tbb/concurrent_hash_map.h
+++ b/include/tbb/concurrent_hash_map.h
@@ -663,21 +663,10 @@ protected:
         // Emplace construct an empty T object inside the pair
         return create_node(allocator, std::piecewise_construct,
                            std::forward_as_tuple(key), std::forward_as_tuple());
-#error // this is not what's under investigation right now
 #else
-        // TODO: A compiler warning has been observed if obj is not initialized,
-        //       but can we also demonstrate failure without the initialization,
-        //       and then add that as a regression test? Unfortunately, it seems that
-        //       the value accidentally starts out as if it were zero-initialized anyway,
-        //       unless the memory is spoiled inside this implementation file,
-        //       so we only have a demonstration but not a regression test.
-        {
-            volatile unsigned int i = 0xDEADBEEF; // this will prevent having obj already be zero by accident
-            ++i;
-        }
         // Use of a temporary object is impossible, because create_node takes a non-const reference.
-        // We can initialize obj as follows because concurrent_hash_map already requires T to be CopyConstructible:
-        T obj;// = T(); // without this initialization and with spoiled memory underneath, the contract is broken
+        // copy-initialization is possible because T is already required to be CopyConstructible.
+        T obj = T();
         return create_node(allocator, key, tbb::internal::move(obj));
 #endif
     }

--- a/include/tbb/concurrent_hash_map.h
+++ b/include/tbb/concurrent_hash_map.h
@@ -663,8 +663,21 @@ protected:
         // Emplace construct an empty T object inside the pair
         return create_node(allocator, std::piecewise_construct,
                            std::forward_as_tuple(key), std::forward_as_tuple());
+#error // this is not what's under investigation right now
 #else
-        T obj; // Use of temporary object in impossible, because create_node takes non-const reference
+        // TODO: A compiler warning has been observed if obj is not initialized,
+        //       but can we also demonstrate failure without the initialization,
+        //       and then add that as a regression test? Unfortunately, it seems that
+        //       the value accidentally starts out as if it were zero-initialized anyway,
+        //       unless the memory is spoiled inside this implementation file,
+        //       so we only have a demonstration but not a regression test.
+        {
+            volatile unsigned int i = 0xDEADBEEF; // this will prevent having obj already be zero by accident
+            ++i;
+        }
+        // Use of a temporary object is impossible, because create_node takes a non-const reference.
+        // We can initialize obj as follows because concurrent_hash_map already requires T to be CopyConstructible:
+        T obj;// = T(); // without this initialization and with spoiled memory underneath, the contract is broken
         return create_node(allocator, key, tbb::internal::move(obj));
 #endif
     }

--- a/src/test/test_aggregator.cpp
+++ b/src/test/test_aggregator.cpp
@@ -132,10 +132,9 @@ public:
 };
 
 class ExpertBody : NoAssign {
-    pq_t& pq;
     tbb::aggregator_ext<my_handler>& agg;
 public:
-    ExpertBody(pq_t& pq_, tbb::aggregator_ext<my_handler>& agg_) : pq(pq_), agg(agg_) {}
+    ExpertBody(tbb::aggregator_ext<my_handler>& agg_) : agg(agg_) {}
     void operator()(const int threadID) const {
         for (int i=0; i<N; ++i) {
             op_data to_push(threadID);
@@ -153,7 +152,7 @@ void TestExpertInterface(int nThreads) {
     tbb::aggregator_ext<my_handler> agg((my_handler(&my_pq)));
     for (int i=0; i<MaxThread; ++i) shared_data[i] = 0;
     REMARK("Testing aggregator expert interface.\n");
-    NativeParallelFor(nThreads, ExpertBody(my_pq, agg));
+    NativeParallelFor(nThreads, ExpertBody(agg));
     for (int i=0; i<nThreads; ++i)
         ASSERT(shared_data[i] == N, "wrong number of elements pushed");
     REMARK("Done testing aggregator expert interface.\n");

--- a/src/test/test_concurrent_hash_map.cpp
+++ b/src/test/test_concurrent_hash_map.cpp
@@ -1612,6 +1612,23 @@ int TestMain () {
     }
     if( MaxThread<2 ) MaxThread=2;
 
+    // Trying to make a regression test for non-initialization
+    {
+        {
+            char buf[1000];
+            memset(buf, static_cast<char>(0xff), sizeof(buf)); // apparently this is not enough to avoid having the inserted value already be zero by accident
+            ASSERT(buf[0] == static_cast<char>(0xff), NULL); // will this avoid having this optimised away?
+        }
+        tbb::concurrent_hash_map<int, double> testmap;
+        tbb::concurrent_hash_map<int, double>::accessor a;
+        for (int i = 0; i < 1000000; ++i) {
+            testmap.insert(a, i); // this currently fails but only with local sabotage
+            ///testmap.insert(a, std::pair<int, double>(i, double())); // this currently works even with local sabotage
+            ASSERT(a->second == double(), NULL);
+        }
+        
+    }
+    
     // Do serial tests
     TestTypes();
     TestCopy();

--- a/src/test/test_concurrent_hash_map.cpp
+++ b/src/test/test_concurrent_hash_map.cpp
@@ -1612,23 +1612,6 @@ int TestMain () {
     }
     if( MaxThread<2 ) MaxThread=2;
 
-    // Trying to make a regression test for non-initialization
-    {
-        {
-            char buf[1000];
-            memset(buf, static_cast<char>(0xff), sizeof(buf)); // apparently this is not enough to avoid having the inserted value already be zero by accident
-            ASSERT(buf[0] == static_cast<char>(0xff), NULL); // will this avoid having this optimised away?
-        }
-        tbb::concurrent_hash_map<int, double> testmap;
-        tbb::concurrent_hash_map<int, double>::accessor a;
-        for (int i = 0; i < 1000000; ++i) {
-            testmap.insert(a, i); // this currently fails but only with local sabotage
-            ///testmap.insert(a, std::pair<int, double>(i, double())); // this currently works even with local sabotage
-            ASSERT(a->second == double(), NULL);
-        }
-        
-    }
-    
     // Do serial tests
     TestTypes();
     TestCopy();

--- a/src/test/test_join_node.cpp
+++ b/src/test/test_join_node.cpp
@@ -126,5 +126,7 @@ int TestMain() {
     test_main<tbb::flow::queueing>();
     test_main<tbb::flow::reserving>();
     test_main<tbb::flow::tag_matching>();
+    // TODO: this now actually exercises the code above, but is just one arbitrary type sufficient (here same as in reference manual example)?
+    generate_recirc_test<tbb::flow::tuple<int,float> >::do_test();
     return Harness::Done;
 }

--- a/src/test/test_join_node.cpp
+++ b/src/test/test_join_node.cpp
@@ -126,7 +126,6 @@ int TestMain() {
     test_main<tbb::flow::queueing>();
     test_main<tbb::flow::reserving>();
     test_main<tbb::flow::tag_matching>();
-    // TODO: this now actually exercises the code above, but is just one arbitrary type sufficient (here same as in reference manual example)?
     generate_recirc_test<tbb::flow::tuple<int,float> >::do_test();
     return Harness::Done;
 }


### PR DESCRIPTION
This points out a few build warnings as seen with Clang on macOS, solving one by initialising a variable before use, and blindly suppressing two others by eliminating an unused variable or a lot of dead code. I have not (yet?) analysed what would be the correct solution for the latter two, and the last one seems particularly problematic (how do you test that your test code is indeed executed...). Moral of the story: warnings are people too, don't ignore them!