### PR TITLE
Remove non-virtual methods from receiver class template

### DIFF
--- a/include/tbb/flow_graph.h
+++ b/include/tbb/flow_graph.h
@@ -461,11 +461,11 @@ public:
     __TBB_DEPRECATED typedef typename internal::async_helpers<T>::filtered_type filtered_type;
 
     //! Put an item to the receiver
-    bool try_put( const typename internal::async_helpers<T>::filtered_type& t ) {
+    virtual bool try_put( const typename internal::async_helpers<T>::filtered_type& t ) {
         return internal::untyped_receiver::try_put(t);
     }
 
-    bool try_put( const typename internal::async_helpers<T>::async_type& t ) {
+    virtual bool try_put( const typename internal::async_helpers<T>::async_type& t ) {
         return internal::untyped_receiver::try_put(t);
     }
 
@@ -539,7 +539,7 @@ public:
     virtual ~receiver() {}
 
     //! Put an item to the receiver
-    bool try_put( const T& t ) {
+    virtual bool try_put( const T& t ) {
         task *res = try_put_task(t);
         if (!res) return false;
         if (res != SUCCESSFULLY_ENQUEUED) internal::spawn_in_graph_arena(graph_reference(), *res);


### PR DESCRIPTION
In some cases it is convenient to build a single node type (sender/receiver) which is composed of multiple other nodes (e.g. function node with bounded queueing policy, which requires limiter and function nodes to be combined). In this case it is beneficial to forward calls to public receiver class methods to some other node, but in order to do that, those methods must be marked as virtual. This PR marks all receiver class template methods as such.